### PR TITLE
Move to next-on-netlify build plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
-  command   = "npm run build"
-  functions = "out_functions"
-  publish   = "out_publish"
+  command = "npm run build"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@ const optimizedImages = require('next-optimized-images')
 const path = require('path')
 
 module.exports = optimizedImages({
+  target: 'serverless',
   webpack(config) {
     config.resolve.alias.images = path.join(__dirname, 'images')
     return config

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,6 @@ const optimizedImages = require('next-optimized-images')
 const path = require('path')
 
 module.exports = optimizedImages({
-  target: 'serverless',
   webpack(config) {
     config.resolve.alias.images = path.join(__dirname, 'images')
     return config

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "nocategory-portfolio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "scripts": {
     "dev": "next",
-    "build": "next build",
-    "postbuild": "next-on-netlify"
+    "build": "next build"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
@@ -18,7 +17,6 @@
     "graphql-request": "^3.2.0",
     "i": "^0.3.6",
     "next": "10.0.3",
-    "next-on-netlify": "^2.6.3",
     "next-optimized-images": "^3.0.0-canary.10",
     "npm": "^6.14.8",
     "react": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,11 +5508,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-compose-plugins@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
-  integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
-
 next-on-netlify@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/next-on-netlify/-/next-on-netlify-2.6.3.tgz#a6e24b5c0504ce2c85e7e59d909b9e4816936df8"


### PR DESCRIPTION
The npm dependency next-on-netlify would require updates over time, while the build plugin is just defined in netlify.toml and not dependent on package.json